### PR TITLE
리포트 수집 관련 기능 추가

### DIFF
--- a/powernad/API/MasterReport.py
+++ b/powernad/API/MasterReport.py
@@ -29,6 +29,10 @@ class MasterReport: #광고정보일괄다운로드탭
         
         result = MasterReportObject(result)
         return result
+    
+    def download_master_report_by_url(self, url: str, localpath: str):
+        result = self.r.download('/report-download', url, localpath)
+        return result
 
     def create_master_report(self, CreateMasterReportObject: CreateMasterReportObject) -> MasterReportObject:
         data = jsonpickle.encode(CreateMasterReportObject, unpicklable=False)
@@ -42,8 +46,7 @@ class MasterReport: #광고정보일괄다운로드탭
         return result
 
     def delete_master_report_all(self):
-        self.r.delete('/master-reports')
-        return True
+        return self.r.delete('/master-reports')
 
     def delete_master_report_by_id(self, id: str):
         self.r.delete('/master-reports', {'id': id})

--- a/powernad/API/StatReport.py
+++ b/powernad/API/StatReport.py
@@ -27,6 +27,10 @@ class StatReport: #대용량 보고서
         result = StatReportObject(result)
         
         return result
+    
+    def download_stat_report_by_url(self, url: str, localpath: str):
+        result = self.r.download('/report-download', url, localpath)
+        return result
 
     def create_stat_report(self, CreateStatReportObject: CreateStatReportObject) -> StatReportObject:
         

--- a/powernad/Object/MasterReport/RequestObject/CreateMasterReportObject.py
+++ b/powernad/Object/MasterReport/RequestObject/CreateMasterReportObject.py
@@ -1,4 +1,13 @@
+from datetime import datetime
+from pytz import timezone
+
 class CreateMasterReportObject:
-    def __init__(self, item, fromTime):
+    def __init__(self, item, fromTime, timeZone='Asia/Seoul'):
         self.item = item
-        self.fromTime = fromTime
+        
+        if fromTime is None:
+            self.fromTime = None
+        elif type(fromTime) == datetime:
+            self.fromTime = fromTime.replace(tzinfo=timezone(timeZone)).isoformat(timespec='seconds')
+        else:
+            raise Exception('type of fromTime should be None or datetime')

--- a/powernad/Object/StatReport/RequestObject/CreateStatReportObject.py
+++ b/powernad/Object/StatReport/RequestObject/CreateStatReportObject.py
@@ -2,4 +2,3 @@ class CreateStatReportObject:
     def __init__(self, reportTp, statDt):
         self.reportTp = reportTp
         self.statDt = statDt
-        #self.customerId = 1109868

--- a/powernad/Object/StatReport/StatReportObject.py
+++ b/powernad/Object/StatReport/StatReportObject.py
@@ -14,3 +14,6 @@ class StatReportObject:
         self.statDt = None if 'statDt' not in s else s['statDt']
         self.status = None if 'status' not in s else s['status']
         self.updateTm = None if 'updateTm' not in s else s['updateTm']
+
+        self.code = None if 'code' not in s else s['code']
+        self.message = None if 'message' not in s else s['message']


### PR DESCRIPTION
devkingsejong님 안녕하세요.
여유있으실 때 검토해 주시길 부탁드립니다.

아래는 제가 작업하면서 메모해놓은 코드 보완 내역입니다.

1.
delete_master_report_all 명령 혹은 get_master_report_list 명령과 같이 정상 통신해도
응답값에 json이 포함되지 않아서 예외 발생해서 오류로 오인하게 하는 문제 개선
 
2.
네이버 json 반환값이 list인 경우를 무시하고 dict만 반환한다는 전제 확장
 
3.
BI 도구가 통신 결과를 정확히 이해하기 위해서 r.status_code == 400 이어서 r.ok == false인
경우에도 text의 code와 message 전달하도록 개선
 
4.
BI 친화적이기 위해서 transation_id를 항상 처리하도록 개선

5. 
master stat 보고서 다운로드 기능 추가

6.
CreateMasterReportObject의 fromtime 인수를 API가 허용하는 형식으로 전처리 코드 추가

7.
계정정보 노출 주석 삭제delete_master_report_all 명령 혹은 get_master_report_list 명령과 같이 정상 통신해도
응답값에 json이 포함되지 않아서 예외 발생해서 오류로 오인하게 하는 문제 개선

8.
네이버 json 반환값이 list인 경우를 무시하고 dict만 반환한다는 전제 확장

9.
BI 도구가 통신 결과를 정확히 이해하기 위해서 r.status_code == 400 이어서 r.ok == false인
경우에도 text의 code와 message 전달하도록 개선

10.
BI 친화적이기 위해서 transation_id를 항상 처리하도록 개선

11.
master stat 보고서 다운로드 기능 추가

12.
CreateMasterReportObject의 fromtime 인수를 API가 허용하는 형식으로 전처리 코드 추가

13.
계정정보 노출 주석 삭제